### PR TITLE
Add SecWebAppIdOnAllCollections flag

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -105,6 +105,7 @@ void *create_directory_config(apr_pool_t *mp, char *path)
     /* Misc */
     dcfg->data_dir = NOT_SET_P;
     dcfg->webappid = NOT_SET_P;
+    dcfg->webappid_on_all_collections = NOT_SET;
     dcfg->sensor_id = NOT_SET_P;
     dcfg->httpBlkey = NOT_SET_P;
 
@@ -536,6 +537,8 @@ void *merge_directory_configs(apr_pool_t *mp, void *_parent, void *_child)
         ? parent->data_dir : child->data_dir);
     merged->webappid = (child->webappid == NOT_SET_P
         ? parent->webappid : child->webappid);
+    merged->webappid_on_all_collections = (child->webappid_on_all_collections == NOT_SET
+        ? parent->webappid_on_all_collections : child->webappid_on_all_collections);
     merged->sensor_id = (child->sensor_id == NOT_SET_P
         ? parent->sensor_id : child->sensor_id);
     merged->httpBlkey = (child->httpBlkey == NOT_SET_P
@@ -699,6 +702,7 @@ void init_directory_config(directory_config *dcfg)
     /* Misc */
     if (dcfg->data_dir == NOT_SET_P) dcfg->data_dir = NULL;
     if (dcfg->webappid == NOT_SET_P) dcfg->webappid = "default";
+    if (dcfg->webappid_on_all_collections == NOT_SET) dcfg->webappid_on_all_collections = 0;
     if (dcfg->sensor_id == NOT_SET_P) dcfg->sensor_id = "default";
     if (dcfg->httpBlkey == NOT_SET_P) dcfg->httpBlkey = NULL;
 
@@ -1204,7 +1208,7 @@ static const char *cmd_audit_log(cmd_parms *cmd, void *_dcfg, const char *p1)
     else {
         const char *file_name = ap_server_root_relative(cmd->pool, dcfg->auditlog_name);
         apr_status_t rc;
-        
+
         if (dcfg->auditlog_fileperms == NOT_SET) {
             dcfg->auditlog_fileperms = CREATEMODE;
         }
@@ -2610,6 +2614,13 @@ static const char *cmd_web_app_id(cmd_parms *cmd, void *_dcfg, const char *p1)
     return NULL;
 }
 
+static const char *cmd_web_app_id_on_all_collections(cmd_parms *cmd, void *_dcfg, int on)
+{
+    directory_config *dcfg = _dcfg;
+    dcfg->webappid_on_all_collections = on;
+    return NULL;
+}
+
 static const char *cmd_sensor_id(cmd_parms *cmd, void *_dcfg, const char *p1)
 {
     directory_config *dcfg = (directory_config *)_dcfg;
@@ -3877,6 +3888,14 @@ const command_rec module_directives[] = {
         NULL,
         CMD_SCOPE_ANY,
         "id"
+    ),
+
+    AP_INIT_FLAG (
+        "SecWebAppIdOnAllCollections",
+        cmd_web_app_id_on_all_collections,
+        NULL,
+        CMD_SCOPE_ANY,
+        "On or Off"
     ),
 
     AP_INIT_TAKE1 (

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -572,6 +572,7 @@ struct directory_config {
     /* Misc */
     const char          *data_dir;
     const char          *webappid;
+    int                 *webappid_on_all_collections;
     const char          *sensor_id;
     const char          *httpBlkey;
 

--- a/apache2/persist_dbm.h
+++ b/apache2/persist_dbm.h
@@ -23,6 +23,6 @@ apr_table_t DSOLOCAL *collection_retrieve(modsec_rec *msr, const char *col_name,
 
 int DSOLOCAL collection_store(modsec_rec *msr, apr_table_t *collection);
 
-int DSOLOCAL collections_remove_stale(modsec_rec *msr, const char *col_name);
+int DSOLOCAL collections_remove_stale(modsec_rec *msr, apr_table_t *collection);
 
 #endif


### PR DESCRIPTION
When set, this flag will cause the GLOBAL and IP collections to be prefixed
with the SecWebAppId for a virtual host that contains rules that manipulate
those collections. Without this flag, the GLOBAL and IP collections are shared
across all virtual hosts for a server. This creates the possibility of
cross-contamination between virtual hosts, and when in an environment where
different users have control of the ModSecurity rules for each hosts, opens the
possibility of attack or incorrect function due to inadvertent conflicts.

The collections_remove_stale persistence layer method signature is changed to
take the apr_table_t representing the collection instead of the collection name
itself, removing duplication of the code that computes the effective collection
name from the base collection name.

The jenkins build is also fixed to work correctly with dev branch builds.

Close #1