### PR TITLE
Build without libcurl (support 18.04)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-
 . versions
 
 VERSION=$1
@@ -37,13 +36,16 @@ printf "libdir = %s/modules\n" "$HTTPD_WS" >>config_vars.mk
 sed -e "s|$HTTPD/build|$WORKSPACE/|" $HTTPD_WS/bin/apxs >apxs
 chmod +x apxs
 
+mkdir -p empty
 ./autogen.sh
 ./configure \
   --prefix="$HTTPD" \
   --libdir="$HTTPD" \
+  --disable-mlogc \
   --with-apr="$HTTPD_WS" \
   --with-apu="$HTTPD_WS" \
   --with-apxs="$WORKSPACE/apxs" \
+  --with-curl="$PWD/empty" \
   --enable-collection-global-lock
 
 make


### PR DESCRIPTION
Libcurl is messy on Ubuntu 18.04 because if you build on a version prior to it
you will not be able run your program on 18.04 due to the way that 16.04 and
before bundled libcurl.so.4 into libcurl.so.3 but defined a symbol
CURL_OPENSSL_3 that causes `CURL_OPENSSL_3 not found` when running a program so
built on 18.04. See https://bugs.launchpad.net/ubuntu/+source/curl/+bug/1754294
for scant additional information.

Fortunately, ModSecurity only needs libcurl for building mlogc, which we do not
use. Nevertheless, it will add libcurl to the link for mod_security and then it
is needed. So, this change will both disable mlogc and disable finding libcurl.

Close #5